### PR TITLE
Update prices and added option to expand 168h tls

### DIFF
--- a/e11-mobile-lel/js/main.js
+++ b/e11-mobile-lel/js/main.js
@@ -510,19 +510,19 @@ function refresh(test, logHeroSouls, xyliqilLevel, chorLevel, autoClickers) {
             if ((zonesGained > 360000) && (this.minZones <= 756000)) {
                 duration = "168h";
                 zonesGained = Math.min(756000, zonesGained);
-                rubyCost += 50;
+                rubyCost += 500;
             } else if ((zonesGained > 144000) && (this.minZones <= 216000)) {
                 duration = "48h";
                 zonesGained = Math.min(216000, zonesGained);
-                rubyCost += 30;
+                rubyCost += 300;
             } else if ((zonesGained > 72000) && (this.minZones <= 108000)) {
                 duration = "24h";
                 zonesGained = Math.min(108000, zonesGained);
-                rubyCost += 20;
+                rubyCost += 200;
             } else if (this.minZones <= 36000) {
                 duration = "8h";
                 zonesGained = Math.min(36000, zonesGained);
-                rubyCost += 10;
+                rubyCost += 100;
             } else { break; }
             highestZone = startingZone + zonesGained;
 
@@ -633,5 +633,13 @@ function changeTheme() {
 $(setDefaults);
 if (localStorage) {
     $("#dark").prop("checked", localStorage.getItem("darkmode")==="true");
+
+    $("#tls").change(function() {
+        if ($(this).is(":checked")) {
+            localStorage.setItem("tlsState", "checked");
+        } else {
+            localStorage.setItem("tlsState", "unchecked");
+        }
+    });
 }
 $(changeTheme);

--- a/index.html
+++ b/index.html
@@ -74,6 +74,8 @@
                             <input type="checkbox" id="dark" class="checkbox" onclick="changeTheme()"><label for="dark">Dark Theme</label>
                             <br>
                             <input type="checkbox" id="primal" class="checkbox" onclick="readSave()"><label for="primal">Use Primal Souls</label>
+							<br>
+							<input type="checkbox" id="tls" class="checkbox" onclick="refresh()"><label for="tls">Expand 168h TLs</label>
 							<br><button id="calculateButton" onclick="refresh()">Calculate</button>
                             <hr>
                             <button id="showAdvanced" onclick="showAdvancedClick()">Show Advanced Settings</button>

--- a/index.html
+++ b/index.html
@@ -41,7 +41,7 @@
 						<div class="title">Info</div>
 						<div class="content">
 							<p>Send your Feedback to: <a href="https://redd.it/7z4982">https://redd.it/7z4982</a></p>
-							<p>Keep at least one Auto Clicker unassigned or you will not benefit from Nogardnit, causing you to lose thousands of zones. (last tested Feb 19 2018)</p>
+							<p>Keep at least one Auto Clicker unassigned or you will not benefit from Nogardnit, causing you to lose thousands of zones. (last tested Dec 22 2024)</p>
 							<p>Hover over the last hero to see when you unlock it!</p>
 						</div>
 					</div>

--- a/js/main.js
+++ b/js/main.js
@@ -418,19 +418,19 @@ function getNextTL(startingZone) {
     if ((zonesGained >= 360000) && (userData.minZones <= 756000) && (needed >= 252000)) {
         duration = "168h";
         zonesGained = Math.min(756000, zonesGained);
-        rubyCost = 50;
+        rubyCost = 500;
     } else if ((zonesGained >= 144000) && (userData.minZones <= 216000) && (needed >= 108000)) {
         duration = "48h";
         zonesGained = Math.min(216000, zonesGained);
-        rubyCost = 30;
+        rubyCost = 300;
     } else if ((zonesGained >= 72000) && (userData.minZones <= 108000) && (needed >= 36000)) {
         duration = "24h";
         zonesGained = Math.min(108000, zonesGained);
-        rubyCost = 20;
+        rubyCost = 200;
     } else if (userData.minZones <= 36000) {
         duration = "8h";
         zonesGained = Math.min(36000, zonesGained);
-        rubyCost = 10;
+        rubyCost = 100;
     } else {
         return [false, zonesGained];
     }
@@ -715,12 +715,14 @@ function refresh(options) {
     let toappend = "";
     let t = 0;
     if (timelapses[4] && timelapses[4].duration === "168h") {
-        for (let d = 4; d < timelapses.length; d++) {
-            if (timelapses[d].duration === "168h") {
-                t = d;
+        if (!$("#tls").is(":checked")) {
+            for (let d = 4; d < timelapses.length; d++) {
+                if (timelapses[d].duration === "168h") {
+                    t = d;
+                }
             }
+            timelapses[t].duration += " x" + (t + 1);
         }
-        timelapses[t].duration += " x" + (t + 1);
         timelapses[t].zoneDisplay = timelapses[t].zone.toLocaleString() + " (+" + (timelapses[t].zone - 40).toLocaleString() + ")";
     }
     for (t; t < timelapses.length; t++) {
@@ -864,6 +866,18 @@ $(setDefaults);
 $(function() {
     if (localStorage) {
         $("#dark").prop("checked", localStorage.getItem("darkmode")==="true");
+        
+        if (localStorage.getItem("tlsState") === "checked") {
+            $("#tls").prop("checked", true);
+        }
+
+        $("#tls").change(function() {
+            if ($(this).is(":checked")) {
+                localStorage.setItem("tlsState", "checked");
+            } else {
+                localStorage.setItem("tlsState", "unchecked");
+            }
+        });
     }
 
     $('.collapsible .title').click(function(){

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-var CACHE_NAME = 'timelapses-cache-v42';
+var CACHE_NAME = 'timelapses-cache-v43';
 var urlsToCache = [
     '.',
     'css/dark-theme-v003.css',


### PR DESCRIPTION
One thing that slightly bugged me was when it had a bunch of 168h tls compacted into one row, I couldn't see the hero that was the strongest between each 168h tl. This adds a checkbox for that. Also, a new update came out which matched the prices of the mobile version to the pc version.